### PR TITLE
Fix string replacement for 4.3 filenames

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -22,7 +22,7 @@ else
     RHCOS_IMAGE_FILENAME_OPENSTACK="$(curl ${RHCOS_IMAGE_URL}/meta.json | jq -r '.images.openstack.path')"
     IMAGE_URL=${RHCOS_IMAGE_URL}
 fi
-RHCOS_IMAGE_FILENAME_COMPRESSED=${RHCOS_IMAGE_FILENAME_OPENSTACK/%openstack.qcow2/compressed.qcow2}
+RHCOS_IMAGE_FILENAME_COMPRESSED=${RHCOS_IMAGE_FILENAME_OPENSTACK/-openstack/-compressed}
 FFILENAME="rhcos-ootpa-latest.qcow2"
 
 mkdir -p /shared/html/images /shared/tmp


### PR DESCRIPTION
4.3 builds have a filename like rhcos-43.80.20191002.1-compressed.x86_64.qcow2
which adds an arch to the filename that didn't exist for 4.2 builds, so we
need to just replace the substring, not match and replace the entire suffix.

This is a backport of https://github.com/openshift-metal3/rhcos-downloader/pull/8