### PR TITLE
Remove unused Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM docker.io/centos:centos7
-
-RUN yum install -y epel-release && yum update -y && yum install -y qemu-img jq xz && yum clean all
-
-COPY ./get-resource.sh /usr/local/bin/get-resource.sh


### PR DESCRIPTION
Dockerfile is not used in Openshift, only Dockerfile.ocp should be
present to avoid confusion.