### PR TITLE
Allow uncompressed input URL

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -15,9 +15,9 @@ fi
 # "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/420.8.20190708.2/rhcos-420.8.20190708.2-openstack.qcow2.gz?sha256=xxx"
 # NOTE: strip sha256 query string in the image url
 RHCOS_IMAGE_URL_STRIPPED=`echo $RHCOS_IMAGE_URL | cut -f 1 -d \?`
-if [[ $RHCOS_IMAGE_URL_STRIPPED =~ qcow2.[gx]z$ ]]; then
+if [[ $RHCOS_IMAGE_URL_STRIPPED =~ qcow2(\.[gx]z)?$ ]]; then
     RHCOS_IMAGE_FILENAME_RAW=$(basename $RHCOS_IMAGE_URL_STRIPPED)
-    RHCOS_IMAGE_FILENAME_OPENSTACK=${RHCOS_IMAGE_FILENAME_RAW/.[gx]z}
+    RHCOS_IMAGE_FILENAME_OPENSTACK=${RHCOS_IMAGE_FILENAME_RAW/%.[gx]z}
     IMAGE_FILENAME_EXTENSION=${RHCOS_IMAGE_FILENAME_RAW/$RHCOS_IMAGE_FILENAME_OPENSTACK}
     IMAGE_URL=$(dirname $RHCOS_IMAGE_URL_STRIPPED)
 else


### PR DESCRIPTION
Don't complain if the input URL doesn't end with .gz or .xz. The enables
us to set up a second-level cache using the same downloader image.