### PR TITLE
Bug 1968754: Unconditionally remove TMPDIR

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -32,6 +32,7 @@ FFILENAME="rhcos-ootpa-latest.qcow2"
 
 mkdir -p /shared/html/images /shared/tmp
 TMPDIR=$(mktemp -d -p /shared/tmp)
+trap "rm -fr $TMPDIR" EXIT
 cd $TMPDIR
 
 # We have a file in the cache that matches the one we want, use it
@@ -73,8 +74,6 @@ if [ -s "${RHCOS_IMAGE_FILENAME_CACHED}.md5sum" ] ; then
     mv $TMPDIR $RHCOS_IMAGE_FILENAME_QCOW
     ln -sf "$RHCOS_IMAGE_FILENAME_QCOW/$RHCOS_IMAGE_FILENAME_CACHED" $FFILENAME
     ln -sf "$RHCOS_IMAGE_FILENAME_QCOW/$RHCOS_IMAGE_FILENAME_CACHED.md5sum" "$FFILENAME.md5sum"
-else
-    rm -rf $TMPDIR
 fi
 
 # For backwards compatibility, if the rhcos image name contains -openstack, we want to


### PR DESCRIPTION
Otherwise this leaks directories (even on success) with large
images inside, eventually using up all disk space in some situations

This has been identified as related to the issues in upgrade CI ref https://bugzilla.redhat.com/show_bug.cgi?id=1968754