### PR TITLE
[release-4.7] Bug 1971549: Unconditionally remove TMPDIR

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -29,6 +29,7 @@ FFILENAME="rhcos-ootpa-latest.qcow2"
 
 mkdir -p /shared/html/images /shared/tmp
 TMPDIR=$(mktemp -d -p /shared/tmp)
+trap "rm -fr $TMPDIR" EXIT
 cd $TMPDIR
 
 # We have a File in the cache that matches the one we want, use it
@@ -65,7 +66,5 @@ if [ -s "${RHCOS_IMAGE_FILENAME_COMPRESSED}.md5sum" ] ; then
     mv $TMPDIR $RHCOS_IMAGE_FILENAME_OPENSTACK
     ln -sf "$RHCOS_IMAGE_FILENAME_OPENSTACK/$RHCOS_IMAGE_FILENAME_COMPRESSED" $FFILENAME
     ln -sf "$RHCOS_IMAGE_FILENAME_OPENSTACK/$RHCOS_IMAGE_FILENAME_COMPRESSED.md5sum" "$FFILENAME.md5sum"
-else
-    rm -rf $TMPDIR
 fi
 


### PR DESCRIPTION
Otherwise this leaks directories (even on success) with large
images inside, eventually using up all disk space in some situations

Conflicts:
	get-resource.sh

(cherry picked from commit ec5bd06afd8a682693e2acc0ffc702d43c961d9f)