### PR TITLE
Do not succeed on HTTP failures

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -58,7 +58,7 @@ else
     MAX_ATTEMPTS=5
 
     for i in $(seq ${MAX_ATTEMPTS}); do
-        if ! curl -g --compressed -L --connect-timeout ${CONNECT_TIMEOUT} -o "${RHCOS_IMAGE_FILENAME_RAW}" "${IMAGE_URL}/${RHCOS_IMAGE_FILENAME_RAW}"; then
+        if ! curl -g --compressed -L --fail --connect-timeout ${CONNECT_TIMEOUT} -o "${RHCOS_IMAGE_FILENAME_RAW}" "${IMAGE_URL}/${RHCOS_IMAGE_FILENAME_RAW}"; then
           if (( ${i} == ${MAX_ATTEMPTS} )); then
             echo "Download failed."
             exit 1


### PR DESCRIPTION
We had issues in the past where an HTTP failure was ignored, and
corrupted content was supplied to Ironic.
