### PR TITLE
Add symlink to help second-level image cache to correctly download the images

### DIFF
--- a/get-live-images.sh
+++ b/get-live-images.sh
@@ -64,6 +64,10 @@ function cache_image() {
 			coreos-installer iso kargs modify -a "$IP_OPTIONS" "$FILENAME/$FILENAME_CACHED"
 		fi
 	fi
+	# We need to create a symlink so that the second-level image cache
+	# can download and prefix 'cached-' to the filename correctly
+	cd $FILENAME
+	ln -sf "$FILENAME_CACHED" "$FILENAME"
 }
 
 mkdir -p /shared/html/images /shared/tmp


### PR DESCRIPTION
The symlink added in this PR should ensure that the second level image cache can correctly fetch and cache images.

See: https://github.com/openshift/cluster-baremetal-operator/pull/174#discussion_r672746609