### PR TITLE
Don't compress the RHCOS image

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -83,7 +83,10 @@ else
         LIBGUESTFS_BACKEND=direct virt-edit -a "$RHCOS_IMAGE_FILENAME_QCOW" -m "$BOOT_DISK" /boot/loader/entries/ostree-1-rhcos.conf -e "s/^options/options ${IP_OPTIONS}/"
     fi
 
-    qemu-img convert -O qcow2 -c "$RHCOS_IMAGE_FILENAME_QCOW" "$RHCOS_IMAGE_FILENAME_CACHED"
+    # For compatibity we need to keep both $RHCOS_IMAGE_FILENAME_QCOW and $RHCOS_IMAGE_FILENAME_CACHED
+    # RHCOS_IMAGE_FILENAME_QCOW is downloaded by the image-cache pods when they initialize
+    # RHCOS_IMAGE_FILENAME_CACHED is used by IPA when provisioning
+    ln -sf "$RHCOS_IMAGE_FILENAME_QCOW" "$RHCOS_IMAGE_FILENAME_CACHED"
     md5sum "$RHCOS_IMAGE_FILENAME_CACHED" | cut -f 1 -d " " > "$RHCOS_IMAGE_FILENAME_CACHED.md5sum"
 fi
 


### PR DESCRIPTION
This compression was added years ago so that IPA running in developemnt
environments with limited RAM could download the image to a tmpfs. It
added 2 to 3 minutes and at the time we cached the image (masters downloaded
it from the bootstrap VM), so it was a single hit.

Fast forward to today, we've removed the caching and now run an additional
image-cache pod on each master. So we're running this 5 times(at least 3 in series).
And the default dev env requirments is now 8G for worker nodes meaning its not needed
any longer.