### PR TITLE
Bug 1990556: Clear proxy env variables if go would have

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,10 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS builder
+
+COPY clearproxy.go clearproxy.go
+RUN go build clearproxy.go
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.10
+COPY --from=builder /go/src/github.com/openshift/origin/clearproxy /usr/local/bin/clearproxy
 
 RUN dnf upgrade -y \
  && dnf install -y qemu-img jq xz libguestfs-tools coreos-installer \

--- a/clearproxy.go
+++ b/clearproxy.go
@@ -1,0 +1,25 @@
+package main
+
+import "net/http"
+import "os"
+
+func main() {
+    if len(os.Args) < 2 {
+        os.Exit(1)
+    }
+    url := os.Args[1]
+
+    r, err := http.NewRequest("GET", url, nil)
+    if err != nil {
+        os.Exit(1)
+    }
+    p, err := http.ProxyFromEnvironment(r)
+    if err != nil {
+        os.Exit(1)
+    }
+    if p == nil {
+		// No proxy returned, we need to clear the proxies
+        os.Exit(0)
+    }
+    os.Exit(1)
+}

--- a/get-resource.sh
+++ b/get-resource.sh
@@ -49,6 +49,12 @@ TMPDIR=$(mktemp -d -p /shared/tmp)
 trap "rm -fr $TMPDIR" EXIT
 cd $TMPDIR
 
+# curl doesn't handle NO_PROXY the same way as code written in golang
+# clear the proxy variables if needed to mimic handling them the golang way
+if clearproxy "${IMAGE_URL}/${RHCOS_IMAGE_FILENAME_RAW}" ; then
+    unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy
+fi
+
 # We have a file in the cache that matches the one we want, use it
 if [ -s "/shared/html/images/$RHCOS_IMAGE_FILENAME_QCOW/$RHCOS_IMAGE_FILENAME_CACHED.md5sum" ]; then
     echo "$RHCOS_IMAGE_FILENAME_QCOW/$RHCOS_IMAGE_FILENAME_CACHED.md5sum found, contents:"


### PR DESCRIPTION
curl interpretes the various proxy related env variables
differently to the golang http library. Add a small utility
to test what golang would have done and clear the proxy
variables if appropriate.

This will better match how proxies are handled in the cluster
and whats documented.


There is a few alternative options for this
1. add a similar utility but written in python
    I opted for the golang alternative as its less likely to have corner cases that mismatch what other images in the cluster do.
2. replace curl with something written in golang
    This would be more likely to introduce a regression and less suitable for backporting. It may be the way to go in a follow up if we want a cleaner solution we don't want to backport.