### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/ironic-rhcos-downloader
+
+go 1.16


### PR DESCRIPTION
This is required for go 1.17 with -mod=vendor (which is set by golang-builder).
