### PR TITLE
Bug 1948538: Clear proxy env variables if go would have

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,10 +1,12 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.7 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+
+WORKDIR /tmp
 
 COPY clearproxy.go clearproxy.go
 RUN go build clearproxy.go
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
-COPY --from=builder /go/src/github.com/openshift/origin/clearproxy /usr/local/bin/clearproxy
+COPY --from=builder /tmp/clearproxy /usr/local/bin/clearproxy
 
 RUN yum update -y \
  && yum install -y qemu-img jq xz libguestfs-tools \

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,8 +1,15 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.7 AS builder
+
+COPY clearproxy.go clearproxy.go
+RUN go build clearproxy.go
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
+COPY --from=builder /go/src/github.com/openshift/origin/clearproxy /usr/local/bin/clearproxy
 
 RUN yum update -y \
  && yum install -y qemu-img jq xz libguestfs-tools \
- && yum clean all
+ && yum clean all \
+ && rm -rf /var/cache/{yum,dnf}/*
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh
 

--- a/clearproxy.go
+++ b/clearproxy.go
@@ -1,0 +1,25 @@
+package main
+
+import "net/http"
+import "os"
+
+func main() {
+    if len(os.Args) < 2 {
+        os.Exit(1)
+    }
+    url := os.Args[1]
+
+    r, err := http.NewRequest("GET", url, nil)
+    if err != nil {
+        os.Exit(1)
+    }
+    p, err := http.ProxyFromEnvironment(r)
+    if err != nil {
+        os.Exit(1)
+    }
+    if p == nil {
+		// No proxy returned, we need to clear the proxies
+        os.Exit(0)
+    }
+    os.Exit(1)
+}

--- a/get-resource.sh
+++ b/get-resource.sh
@@ -34,6 +34,12 @@ TMPDIR=$(mktemp -d -p /shared/tmp)
 trap "rm -fr $TMPDIR" EXIT
 cd $TMPDIR
 
+# curl doesn't handle NO_PROXY the same way as code written in golang
+# clear the proxy variables if needed to mimic handling them the golang way
+if clearproxy "${IMAGE_URL}/${RHCOS_IMAGE_FILENAME_RAW}" ; then
+    unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy
+fi
+
 # We have a File in the cache that matches the one we want, use it
 if [ -s "/shared/html/images/$RHCOS_IMAGE_FILENAME_OPENSTACK/$RHCOS_IMAGE_FILENAME_COMPRESSED.md5sum" ]; then
     echo "$RHCOS_IMAGE_FILENAME_OPENSTACK/$RHCOS_IMAGE_FILENAME_COMPRESSED.md5sum found, contents:"


### PR DESCRIPTION
Clear proxy env variables if go would have

curl interpretes the various proxy related env variables
differently to the golang http library. Add a small utility
to test what golang would have done and clear the proxy
variables if appropriate.

This will better match how proxies are handled in the cluster
and whats documented.

Also cherry-pick of https://github.com/openshift/ironic-rhcos-downloader/commit/af79eb4198df39012c58e4305c53d8f0318d1a50 which
changes where the utility if built (so it doesn't break in ART)
