### PR TITLE
[release-4.12] OCPBUGS-87168: CI Build root image tag and go version in go.mod sync with ART 4.12

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.15
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/openshift/ironic-rhcos-downloader
 
-go 1.16
+go 1.19


### PR DESCRIPTION
Updated the CI Build Root image tag for the 4.12 branch to align with Golang builder version 1.19 from the ART 4.12 stream. we had to choose rhel8 image tag as there is no rhel 9 specific image tag available for 4.12 stream.

minimum golang version in go.mod is also synced with ART 4.12 stream 

Impact: This alignment ensures uniformity between Prow CI testing and ART build/shipment processes by locking them to the same Golang version.