### PR TITLE
[release-4.14] OCPBUGS-87171: CI image build root tag and go version in go.mod sync with ART 4.14 config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.15
+  tag: rhel-9-release-golang-1.20-openshift-4.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/openshift/ironic-rhcos-downloader
 
-go 1.16
+go 1.20


### PR DESCRIPTION
Updated the CI Build Root image tag for the 4.14 branch to align with Golang builder version 1.20 from the ART 4.14 stream.

minimum golang version in go.mod is also synced with ART 4.14 stream

Impact: This alignment ensures uniformity between Prow CI testing and ART build/shipment processes by locking them to the same Golang version.